### PR TITLE
Add default tooltip with icon

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,8 @@
     },
     "browser_action": {
         "default_icon": "images/logo.png",
-        "default_popup": "options.html"
+        "default_popup": "options.html",
+        "default_title": "Codeforces Analytics"
     },
     "manifest_version": 2
 }


### PR DESCRIPTION
Tooltip can be found by hovering over the extension icon.

![untitled](https://user-images.githubusercontent.com/9162661/53683220-290f4a00-3cf6-11e9-8423-fe82bf050bb2.png)
